### PR TITLE
Restore ER diagram relationships

### DIFF
--- a/components/databases/ERDiagramView.tsx
+++ b/components/databases/ERDiagramView.tsx
@@ -68,6 +68,20 @@ export default function ERDiagramView({ schema }: ERDiagramViewProps) {
             <code>PK</code> = Primary Key, <code>UK</code> = Unique,{" "}
             <code>NULL</code> = Nullable
           </li>
+          {schema.relationships?.length ? (
+            <>
+              <li className="pt-2 font-semibold text-[--brand-text-primary]">
+                Relationships
+              </li>
+              {schema.relationships.map((r, idx) => (
+                <li key={idx} className="ml-2">
+                  <code>
+                    {r.fromTable}.{r.fromColumn} → {r.toTable}.{r.toColumn}
+                  </code>
+                </li>
+              ))}
+            </>
+          ) : null}
         </ul>
       </div>
     </div>

--- a/lib/erDiagram.ts
+++ b/lib/erDiagram.ts
@@ -56,5 +56,19 @@ export function generateERDiagram(schema: SchemaData): string {
   diagram += `  %% o{--o{  Many to Many\n`;
   diagram += `  %% PK = Primary Key, UK = Unique, NULL = Nullable\n`;
 
+  if (schema.relationships?.length) {
+    diagram += `  %% Relationships\n`;
+    for (const rel of schema.relationships) {
+      if (
+        rel.fromTable &&
+        rel.fromColumn &&
+        rel.toTable &&
+        rel.toColumn
+      ) {
+        diagram += `  %% ${rel.fromTable}.${rel.fromColumn} -> ${rel.toTable}.${rel.toColumn}\n`;
+      }
+    }
+  }
+
   return diagram;
 }

--- a/lib/schemaParsers.ts
+++ b/lib/schemaParsers.ts
@@ -28,8 +28,12 @@ export function parseSQLSchema(sql: string): SchemaData {
       if (fkMatch) {
         const [, fromColumn, toTable, toColumn] = fkMatch;
         relationships.push({
-          source: fromColumn,
-          target: toColumn,
+          fromTable: tableName,
+          toTable,
+          fromColumn,
+          toColumn,
+          source: tableName,
+          target: toTable,
           type: "OneToMany",
         });
         return;
@@ -93,9 +97,12 @@ export function parsePrismaSchema(prisma: string): SchemaData {
           const toColumn = referencesMatch[1];
 
           relationships.push({
+            fromTable: modelName,
+            toTable: referencedModel,
+            fromColumn,
+            toColumn,
             source: modelName,
             target: referencedModel,
-
             type: "OneToMany",
           });
         }
@@ -155,6 +162,10 @@ export function parseDbmlSchema(dbml: string): SchemaData {
   while ((match = refRegex.exec(dbml)) !== null) {
     const [, fromTable, fromColumn, toTable, toColumn] = match;
     relationships.push({
+      fromTable,
+      toTable,
+      fromColumn,
+      toColumn,
       source: fromTable,
       target: toTable,
       type: "OneToMany",


### PR DESCRIPTION
## Summary
- include table and column names in parsed relationships
- display relationship list alongside the ER legend
- output relationships as comments in generated Mermaid diagrams

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684052e32dbc8323805de81fe7a7e0c7