### PR TITLE
Add 'New Schema' option on database page

### DIFF
--- a/app/(protected)/projects/[projectId]/databases/page.tsx
+++ b/app/(protected)/projects/[projectId]/databases/page.tsx
@@ -194,6 +194,13 @@ export default function DatabaseTab() {
     setSelectedSchemaId(id);
   };
 
+  const handleNewSchema = () => {
+    const empty = { tables: [], relationships: [] } as SchemaData;
+    setSchema(empty);
+    setRenderSchema(empty);
+    setSelectedSchemaId(null);
+  };
+
   const handleExport = () => {
     const output = exportSchema(schema, exportFormat);
     saveAs(
@@ -320,6 +327,7 @@ export default function DatabaseTab() {
     schemas,
     selectedSchemaId,
     onLoadSchema: handleLoadSchema,
+    onNewSchema: handleNewSchema,
   };
   const tableListProps = {
     tables: schema?.tables,

--- a/components/databases/SchemaDropzone.tsx
+++ b/components/databases/SchemaDropzone.tsx
@@ -6,6 +6,8 @@ interface Props {
   schemas: Array<{ id: string; title: string }>;
   selectedSchemaId: string | null;
   onLoadSchema: (id: string) => void;
+  /** Triggered when the user selects to start a new schema */
+  onNewSchema: () => void;
 }
 
 export default function SchemaDropzone({
@@ -14,6 +16,7 @@ export default function SchemaDropzone({
   schemas,
   selectedSchemaId,
   onLoadSchema,
+  onNewSchema,
 }: Props) {
   return (
     <>
@@ -29,10 +32,18 @@ export default function SchemaDropzone({
 
         <select
           value={selectedSchemaId || ""}
-          onChange={(e) => onLoadSchema(e.target.value)}
+          onChange={(e) => {
+            const val = e.target.value;
+            if (val === "__new__") {
+              onNewSchema();
+            } else {
+              onLoadSchema(val);
+            }
+          }}
           className="border px-2 py-1 rounded"
         >
           <option value="">— Load Schema —</option>
+          <option value="__new__">New Schema</option>
           {schemas.map((s) => (
             <option key={s.id} value={s.id}>
               {s.title}


### PR DESCRIPTION
## Summary
- support creating a blank schema from the dropzone
- track new schema option from the database page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68406748d18083238c435b865ecf638c