### PR TITLE
Fix schema import and diagram reset

### DIFF
--- a/app/(protected)/projects/[projectId]/databases/page.tsx
+++ b/app/(protected)/projects/[projectId]/databases/page.tsx
@@ -95,11 +95,8 @@ export default function DatabaseTab() {
     );
   };
 
-  const onFileDrop = async (e: React.DragEvent<HTMLDivElement>) => {
-    e.preventDefault();
+  const handleFileUpload = async (file: File) => {
     setDropError(null);
-    const file = e.dataTransfer?.files?.[0];
-    if (!file) return;
     try {
       const parsed = await parseUploadedSchema(file);
       if (parsed?.tables?.length === 0)
@@ -322,7 +319,7 @@ export default function DatabaseTab() {
     onSaveNewSchema: saveNewSchema,
   };
   const dropzoneProps = {
-    onFileDrop,
+    onFileDrop: handleFileUpload,
     dropError,
     schemas,
     selectedSchemaId,

--- a/components/databases/ERDiagramView.tsx
+++ b/components/databases/ERDiagramView.tsx
@@ -20,8 +20,14 @@ export default function ERDiagramView({ schema }: ERDiagramViewProps) {
   const [definition, setDefinition] = useState<string | null>(null);
 
   useEffect(() => {
-    // Guard: need at least one table with a named column
-    if (!schema?.tables?.length || !schema.tables[0]?.columns?.length) return;
+    // Guard: need at least one table with columns. If none, clear the diagram.
+    if (
+      !schema?.tables?.length ||
+      !schema.tables.some((t) => t?.columns?.length)
+    ) {
+      setDefinition(null);
+      return;
+    }
 
     const generated = generateERDiagram(schema);
     setDefinition(generated);

--- a/components/databases/SchemaDropzone.tsx
+++ b/components/databases/SchemaDropzone.tsx
@@ -1,7 +1,7 @@
 import { P } from "../ui/Typography";
 
 interface Props {
-  onFileDrop: (e: React.DragEvent<HTMLDivElement>) => void;
+  onFileDrop: (file: File) => void;
   dropError: string | null;
   schemas: Array<{ id: string; title: string }>;
   selectedSchemaId: string | null;
@@ -18,17 +18,43 @@ export default function SchemaDropzone({
   onLoadSchema,
   onNewSchema,
 }: Props) {
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const file = e.dataTransfer?.files?.[0];
+    if (file) onFileDrop(file);
+  };
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) onFileDrop(file);
+    e.target.value = ""; // allow re-uploading same file
+  };
+
   return (
     <>
       <div
         className="flex justify-between items-center flex-wrap gap-4 border-2 border-dashed border-blue-300 rounded p-5 w-full"
         onDragOver={(e) => e.preventDefault()}
-        onDrop={onFileDrop}
+        onDrop={handleDrop}
       >
         <h2 className="text-lg font-semibold">Database Schema</h2>
         <small className="text-gray-500">
           Drag a file to upload (.sql, .prisma, .dbml, .json)
         </small>
+
+        <input
+          id="schema-file-input"
+          type="file"
+          accept=".sql,.prisma,.dbml,.json"
+          className="hidden"
+          onChange={handleFileSelect}
+        />
+        <label
+          htmlFor="schema-file-input"
+          className="cursor-pointer rounded border px-2 py-1"
+        >
+          Choose File
+        </label>
 
         <select
           value={selectedSchemaId || ""}


### PR DESCRIPTION
## Summary
- make SchemaDropzone accept File objects and support file input
- ensure ER diagram resets when schema is cleared
- update database page to use new upload function

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_68406b3a96548323874c338ebe7cae1a